### PR TITLE
Inline CSS

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,12 +6,13 @@ import path from 'path';
 
 import { preloadDynamicChunks } from './vite/preload-chunks';
 import { prerenderPlugin } from './vite/prerender';
+import { inlineCss } from './vite/inline-css';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [svelte(), tailwindcss(), preloadDynamicChunks(), prerenderPlugin()],
+  plugins: [svelte(), tailwindcss(), preloadDynamicChunks(), prerenderPlugin(), inlineCss()],
   resolve: {
     alias: {
       '$lib': path.resolve(__dirname, './src/lib'),

--- a/vite/inline-css.ts
+++ b/vite/inline-css.ts
@@ -1,0 +1,34 @@
+import type { Plugin, Rollup } from 'vite';
+
+/**
+ * Inlines CSS into the HTML document.
+ * Eliminates the render-blocking CSS request for faster first paint.
+ */
+export function inlineCss(): Plugin {
+  return {
+    name: 'inline-css',
+    enforce: 'post',
+    transformIndexHtml(html, ctx) {
+      if (!ctx.bundle) return html;
+
+      // Find the CSS asset in the bundle
+      const cssFileName = Object.keys(ctx.bundle).find(name => name.endsWith('.css'));
+      if (!cssFileName) return html;
+
+      const cssChunk = ctx.bundle[cssFileName] as Rollup.OutputAsset;
+      if (cssChunk.type !== 'asset' || typeof cssChunk.source !== 'string') {
+        return html;
+      }
+
+      // Remove the CSS file from bundle so it's not emitted
+      delete ctx.bundle[cssFileName];
+
+      // Replace the stylesheet link with an inline style tag
+      return html.replace(
+        /<link rel="stylesheet"[^>]*>/,
+        `<style>${cssChunk.source}</style>`
+      );
+    },
+  };
+}
+


### PR DESCRIPTION
CSS gzipped is only 6.5kb, so we should be able to inline in the HTML to improve FCP and reduce network requests.