### PR TITLE
Implement cmd/ctrl + enter shortcut for running code with hover tip

### DIFF
--- a/src/lib/components/TabBar.svelte
+++ b/src/lib/components/TabBar.svelte
@@ -19,7 +19,10 @@
   
   // Delay before showing stop button to avoid flash on fast scripts
   let showStopButton = $state(false);
-  
+
+  const isMac = /Mac/i.test(navigator.platform);
+  const runShortcut = isMac ? '⌘↵' : 'Ctrl+↵';
+
   $effect(() => {
     if (!$isRunning) {
       showStopButton = false;
@@ -244,12 +247,12 @@
       <span class="hidden sm:inline">Check</span>
       <span class="sm:hidden"><Icon name="check"size={16} /></span>
     </Button>
-    <Button 
-      size="sm" 
-      variant={showStopButton ? 'secondary' : 'default'} 
-      onclick={handleRun} 
-      class="px-2 sm:px-3" 
-      title={showStopButton ? 'Stop execution' : 'Run code'}
+    <Button
+      size="sm"
+      variant={showStopButton ? 'secondary' : 'default'}
+      onclick={handleRun}
+      class="px-2 sm:px-3"
+      title={showStopButton ? 'Stop execution' : `Run code (${runShortcut})`}
     >
       <span class="sm:mr-1"><Icon name={showStopButton ? 'stop' : 'play'} size={16} /></span>
       <span class="hidden sm:inline">{showStopButton ? 'Stop' : 'Run'}</span>

--- a/src/lib/editor/setup.ts
+++ b/src/lib/editor/setup.ts
@@ -19,7 +19,8 @@ import { luauLspExtensions } from './lspExtensions';
 import { luauEnterKeymap, luauIndentation } from './luauBlocks';
 import { forceLinting, lintGutter } from '@codemirror/lint';
 import { themeMode } from '$lib/utils/theme';
-import { cursorLine } from '$lib/stores/playground';
+import { cursorLine, isRunning } from '$lib/stores/playground';
+import { runCode, stopExecution } from '$lib/luau/wasm';
 import { get } from 'svelte/store';
 
 let editorView: EditorView | null = null;
@@ -66,6 +67,7 @@ function createExtensions(onChange: (content: string) => void): Extension[] {
     keymap.of([
       ...luauEnterKeymap,
       ...closeBracketsKeymap,
+      { key: 'Mod-Enter', run: () => { get(isRunning) ? stopExecution() : runCode(); return true; } },
       ...defaultKeymap,
       ...searchKeymap,
       ...historyKeymap,


### PR DESCRIPTION
Hovering over the "Run" button now shows this hint, and the keyboard shortcut now toggles Play/Stop:
<img width="97" height="75" alt="image" src="https://github.com/user-attachments/assets/3b977085-5f7b-4a91-9a5b-b43aa1340278" />