### PR TITLE
Automate Luau TextMate grammar updates

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -70,6 +70,10 @@ runs:
         node-version: 24
         cache: npm
 
+    - name: Sync TextMate grammar
+      shell: bash
+      run: npm run sync:grammar
+
     - name: Install dependencies
       shell: bash
       run: npm ci

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "vite",
+    "sync:grammar": "node scripts/sync-textmate-grammar.mjs",
     "build:wasm": "cd wasm && ./build.sh",
     "prebuild": "npm run build:wasm",
     "build": "vite build",

--- a/scripts/sync-textmate-grammar.mjs
+++ b/scripts/sync-textmate-grammar.mjs
@@ -1,0 +1,45 @@
+import { createHash } from 'node:crypto';
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const grammarUrl =
+  process.env.LUAU_TEXTMATE_GRAMMAR_URL ??
+  'https://raw.githubusercontent.com/JohnnyMorganz/Luau.tmLanguage/main/Luau.tmLanguage.json';
+const grammarPath = fileURLToPath(
+  new URL('../src/lib/editor/Luau.tmLanguage.json', import.meta.url),
+);
+const temporaryPath = `${grammarPath}.tmp`;
+
+const response = await fetch(grammarUrl, {
+  headers: { 'User-Agent': 'luau-playground-grammar-sync' },
+});
+
+if (!response.ok) {
+  throw new Error(
+    `Unable to download Luau TextMate grammar: ${response.status} ${response.statusText}`,
+  );
+}
+
+const grammarSource = await response.text();
+const grammar = JSON.parse(grammarSource);
+
+if (grammar.name !== 'Luau' || grammar.scopeName !== 'source.luau') {
+  throw new Error('Downloaded file is not the expected Luau TextMate grammar');
+}
+
+let currentSource;
+try {
+  currentSource = await readFile(grammarPath, 'utf8');
+} catch (error) {
+  if (error.code !== 'ENOENT') throw error;
+}
+
+const digest = createHash('sha256').update(grammarSource).digest('hex').slice(0, 12);
+
+if (currentSource === grammarSource) {
+  console.log(`TextMate grammar is already current (${digest})`);
+} else {
+  await writeFile(temporaryPath, grammarSource);
+  await rename(temporaryPath, grammarPath);
+  console.log(`Updated TextMate grammar from upstream (${digest})`);
+}


### PR DESCRIPTION
## Summary
- sync and validate the latest upstream Luau TextMate grammar during the shared build workflow
- expose the synchronization as an npm script for local use

## Test plan
- [x] Run `npm run sync:grammar`
- [x] Run `npm run check`
- [x] Run `npx vite build --base=./`
