### PR TITLE
Remove the `WASM_BIGINT` build option.

### DIFF
--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -211,7 +211,6 @@ if(EMSCRIPTEN)
         -O3
         -flto
         --closure 1
-        -sWASM_BIGINT=1
         
         # Dead code elimination
         -Wl,--gc-sections


### PR DESCRIPTION
This option was deprecated and is slated for removal. My understanding is it is effectively enabled by default now, so we can just pull it from our CMake options.